### PR TITLE
Add regression tests for chain Fisher IPD

### DIFF
--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,18 +1,27 @@
-﻿# Reproducibility Notes
+# Reproducibility Notes
 
-This repository reproduces LCI calculations and the IPD figure using only public inputs.
+This repository reproduces LCI calculations and the IPD figure using only the
+files tracked in git. When the proprietary input bundles are missing, the demo
+scripts fabricate deterministic seed data so that every stage of the pipeline
+still runs to completion.
 
-## One-command run
-1. Install requirements: \pip install -r requirements.txt\
-2. Ensure CSV inputs exist under \data/external\ and \data/evals\ following the schema files.
-3. Run:
-   - \python src/lci_program.py\
-   - \python src/make_ipd.py\
-   - \python src/figures.py\
+## Quickstart
+1. Install requirements: `pip install -r requirements.txt`
+2. (Optional) Drop real CSV inputs under `data/external/` and `data/evals/` to
+   replace the demo seeds.
+3. Run the main pipeline:
+   - `python src/lci_program.py`
+   - `python src/make_ipd.py`
+   - `python src/figures.py`
 
 ## Metadata capture
-Each run writes \esults/meta.json\ (UTC timestamp, Python version, platform, package versions).
-
+`results/meta.json` records the UTC timestamp, Python version, and platform for
+each tool invocation.
+- If inputs are missing, `src/generate_demo_results.py` backfills
+  `results/tables/lci_by_family.csv`, `ipd.csv`, and `lci_by_family.tex` with
+  deterministic sample data.
+- Figures include captions and units. Latency is measured in milliseconds;
+  prices in USD.
 ## Notes
 - If some inputs are missing, scripts emit template CSVs with the correct headers and exit with an informative message.
 - Figures include captions and units. Latency in milliseconds; prices in USD.

--- a/src/figures.py
+++ b/src/figures.py
@@ -10,9 +10,10 @@ def plot_lci_scatter():
         print("[WARN] lci_by_family.csv not found.")
         return
     df = pd.read_csv(p)
+    x_col = "accuracy" if "accuracy" in df.columns else "a"
     for fam, df_f in df.groupby("family"):
         fig, ax = plt.subplots()
-        ax.scatter(df_f["a"], df_f["LCI"])
+        ax.scatter(df_f[x_col], df_f["LCI"])
         ax.set_title(f"LCI vs Accuracy — {fam}")
         ax.set_xlabel("Accuracy")
         ax.set_ylabel("LCI (USD per task-equivalent)")

--- a/src/generate_demo_results.py
+++ b/src/generate_demo_results.py
@@ -1,62 +1,237 @@
-﻿from pathlib import Path
-import pandas as pd
+"""Utility script that fabricates demo LCI/IPD tables when raw inputs are absent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
 import numpy as np
+import pandas as pd
+
+from make_ipd import chain_fisher
+
 
 ROOT = Path(__file__).resolve().parents[1]
 INTERIM = ROOT / "data" / "interim"
-TABLES = (ROOT / "results" / "tables"); TABLES.mkdir(parents=True, exist_ok=True)
-FIGS   = (ROOT / "results" / "figures"); FIGS.mkdir(parents=True, exist_ok=True)
+TABLES = ROOT / "results" / "tables"
+FIGURES = ROOT / "results" / "figures"
 
-merged = INTERIM / "merged_inputs.csv"
-if not merged.exists() or merged.stat().st_size < 10:
-    df = pd.DataFrame([
-        {"date":"2025-01-01","family":"QA","provider":"example","model":"example-A","region":"global",
-         "a":0.80,"p50_ms":300,"p95_ms":450,"q":0.999,"s":0.999,"tokens_per_sec":0,
-         "price_per_token_usd":1.0e-5,"ops_pct":0.0},
-        {"date":"2025-01-01","family":"Code","provider":"example","model":"example-B","region":"global",
-         "a":0.70,"p50_ms":400,"p95_ms":600,"q":0.999,"s":0.999,"tokens_per_sec":0,
-         "price_per_token_usd":1.2e-5,"ops_pct":0.0},
-        {"date":"2025-01-01","family":"Summarization","provider":"example","model":"example-C","region":"global",
-         "a":0.75,"p50_ms":350,"p95_ms":500,"q":0.999,"s":0.999,"tokens_per_sec":0,
-         "price_per_token_usd":9.0e-6,"ops_pct":0.0},
-    ])
-else:
-    df = pd.read_csv(merged)
 
-BAR_L = 500.0
-phi = df["a"].clip(lower=1e-6) * (BAR_L / np.maximum(df["p95_ms"].astype(float).clip(lower=1.0), BAR_L))**0.5
-cost = df["price_per_token_usd"].astype(float).clip(lower=1e-10)
-lci = (cost / phi).rename("LCI")
-df_calc = df.assign(phi=phi, LCI=lci)
+def _ensure_table_dirs() -> None:
+    """Create the results sub-directories that the report expects."""
 
-by_family = (df_calc.groupby("family", as_index=False)
-             .agg(LCI=("LCI","median"),
-                  accuracy=("a","median"),
-                  p95_ms=("p95_ms","median"),
-                  price_per_token_usd=("price_per_token_usd","median"))
-             ).sort_values("LCI")
+    TABLES.mkdir(parents=True, exist_ok=True)
+    FIGURES.mkdir(parents=True, exist_ok=True)
 
-(TABLES / "lci_by_family.csv").write_text(by_family.to_csv(index=False), encoding="utf-8")
-pd.DataFrame({"date":["2025-01-01","2025-06-01","2025-10-01"],"IPD":[1.00,0.94,0.91]}).to_csv(TABLES/"ipd.csv", index=False)
 
-tex = "\\n".join([
-    "\\\\begin{table}[t]",
-    "\\\\centering",
-    "\\\\caption{LCI by Task Family (demo)}",
-    "\\\\label{tab:lci_by_family}",
-    "\\\\begin{tabular}{lrrrr}",
-    "\\\\toprule",
-    "Family & LCI & Accuracy & p95 (ms) & Price/Token \\\\\\\\",
-    "\\\\midrule",
-] + [
-    f"{r['family']} & {r['LCI']:.2e} & {r['accuracy']:.3f} & {r['p95_ms']:.0f} & {r['price_per_token_usd']:.2e} \\\\\\\\"
-    for _, r in by_family.iterrows()
-] + [
-    "\\\\bottomrule",
-    "\\\\end{tabular}",
-    "\\\\end{table}",
-    ""
-])
-(TABLES / "lci_by_family.tex").write_text(tex, encoding="utf-8")
+def demo_dataframe() -> pd.DataFrame:
+    """Return a deterministic seed dataset covering multiple families and dates."""
 
-print("OK: generated results/tables/{lci_by_family.csv, ipd.csv, lci_by_family.tex}")
+    rows = [
+        {
+            "date": "2025-01-01",
+            "family": "QA",
+            "provider": "example",
+            "model": "example-A",
+            "region": "global",
+            "accuracy": 0.80,
+            "a": 0.80,
+            "p50_ms": 300,
+            "p95_ms": 450,
+            "q": 0.999,
+            "s": 0.999,
+            "tokens_per_sec": 0,
+            "price_per_token_usd": 1.0e-5,
+            "ops_pct": 0.0,
+        },
+        {
+            "date": "2025-01-01",
+            "family": "Code",
+            "provider": "example",
+            "model": "example-B",
+            "region": "global",
+            "accuracy": 0.70,
+            "a": 0.70,
+            "p50_ms": 400,
+            "p95_ms": 600,
+            "q": 0.999,
+            "s": 0.999,
+            "tokens_per_sec": 0,
+            "price_per_token_usd": 1.2e-5,
+            "ops_pct": 0.0,
+        },
+        {
+            "date": "2025-01-01",
+            "family": "Summarization",
+            "provider": "example",
+            "model": "example-C",
+            "region": "global",
+            "accuracy": 0.75,
+            "a": 0.75,
+            "p50_ms": 350,
+            "p95_ms": 500,
+            "q": 0.999,
+            "s": 0.999,
+            "tokens_per_sec": 0,
+            "price_per_token_usd": 9.0e-6,
+            "ops_pct": 0.0,
+        },
+        {
+            "date": "2025-06-01",
+            "family": "QA",
+            "provider": "example",
+            "model": "example-A2",
+            "region": "global",
+            "accuracy": 0.82,
+            "a": 0.82,
+            "p50_ms": 290,
+            "p95_ms": 430,
+            "q": 0.999,
+            "s": 0.999,
+            "tokens_per_sec": 0,
+            "price_per_token_usd": 9.5e-6,
+            "ops_pct": 0.0,
+        },
+        {
+            "date": "2025-06-01",
+            "family": "Code",
+            "provider": "example",
+            "model": "example-B2",
+            "region": "global",
+            "accuracy": 0.72,
+            "a": 0.72,
+            "p50_ms": 360,
+            "p95_ms": 540,
+            "q": 0.999,
+            "s": 0.999,
+            "tokens_per_sec": 0,
+            "price_per_token_usd": 1.1e-5,
+            "ops_pct": 0.0,
+        },
+        {
+            "date": "2025-06-01",
+            "family": "Summarization",
+            "provider": "example",
+            "model": "example-C2",
+            "region": "global",
+            "accuracy": 0.77,
+            "a": 0.77,
+            "p50_ms": 330,
+            "p95_ms": 490,
+            "q": 0.999,
+            "s": 0.999,
+            "tokens_per_sec": 0,
+            "price_per_token_usd": 8.5e-6,
+            "ops_pct": 0.0,
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def load_inputs() -> pd.DataFrame:
+    """Load merged inputs or fall back to the deterministic seed dataset."""
+
+    merged = INTERIM / "merged_inputs.csv"
+    if not merged.exists():
+        df = demo_dataframe()
+    else:
+        df = pd.read_csv(merged)
+        if df.empty:
+            df = demo_dataframe()
+
+    if "accuracy" not in df.columns and "a" in df.columns:
+        df["accuracy"] = df["a"]
+    if "a" not in df.columns and "accuracy" in df.columns:
+        df["a"] = df["accuracy"]
+    return df
+
+
+def compute_lci_by_family(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate raw rows into per-family LCI slices."""
+
+    BAR_L = 500.0
+
+    df = df.copy()
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df = df.dropna(subset=["date", "a", "p95_ms", "price_per_token_usd"])
+    phi = df["a"].astype(float).clip(lower=1e-6) * (
+        BAR_L / np.maximum(df["p95_ms"].astype(float).clip(lower=1.0), BAR_L)
+    ) ** 0.5
+    cost = df["price_per_token_usd"].astype(float).clip(lower=1e-10)
+    df["LCI"] = cost / phi
+
+    by_family = (
+        df.groupby(["date", "family"], as_index=False)
+        .agg(
+            LCI=("LCI", "median"),
+            accuracy=("accuracy", "median"),
+            p95_ms=("p95_ms", "median"),
+            price_per_token_usd=("price_per_token_usd", "median"),
+        )
+        .sort_values(["date", "LCI"])
+    )
+    by_family["date"] = by_family["date"].dt.strftime("%Y-%m-%d")
+    return by_family
+
+
+def export_latex_table(by_family: pd.DataFrame) -> None:
+    """Write a LaTeX table containing the latest snapshot."""
+
+    if by_family.empty:
+        return
+
+    latest_date = by_family["date"].max()
+    latest_rows = by_family[by_family["date"] == latest_date]
+    header = [
+        "\\begin{table}[t]",
+        "\\centering",
+        "\\caption{LCI by Task Family (demo)}",
+        "\\label{tab:lci_by_family}",
+        "\\begin{tabular}{lrrrr}",
+        "\\toprule",
+        "Family & LCI & Accuracy & p95 (ms) & Price/Token " + "\\\\",
+        "\\midrule",
+    ]
+    body = [
+        (
+            f"{r['family']} & {r['LCI']:.2e} & {r['accuracy']:.3f} "
+            f"& {r['p95_ms']:.0f} & {r['price_per_token_usd']:.2e} "
+            "\\\\"
+        )
+        for _, r in latest_rows.iterrows()
+    ]
+    footer = [
+        "\\bottomrule",
+        "\\end{tabular}",
+        "\\end{table}",
+        "",
+    ]
+    tex = "\n".join(header + body + footer)
+    (TABLES / "lci_by_family.tex").write_text(tex, encoding="utf-8")
+
+
+def export_ipd(by_family: pd.DataFrame) -> None:
+    """Derive a demo IPD series from the per-family slices."""
+
+    if by_family.empty:
+        (TABLES / "ipd.csv").write_text("date,IPD\n", encoding="utf-8")
+        return
+
+    lci_for_chain = by_family[["date", "family", "LCI"]].copy()
+    lci_for_chain["date"] = pd.to_datetime(lci_for_chain["date"], errors="coerce")
+    lci_for_chain = lci_for_chain.dropna()
+    ipd = chain_fisher(lci_for_chain)
+    ipd.to_csv(TABLES / "ipd.csv", index=False)
+
+
+def main() -> None:
+    _ensure_table_dirs()
+    df = load_inputs()
+    by_family = compute_lci_by_family(df)
+    by_family.to_csv(TABLES / "lci_by_family.csv", index=False)
+    export_ipd(by_family)
+    export_latex_table(by_family)
+    print("[OK] generated results/tables/{lci_by_family.csv, ipd.csv, lci_by_family.tex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_chain_fisher.py
+++ b/tests/test_chain_fisher.py
@@ -1,0 +1,47 @@
+"""Unit tests for the chain Fisher IPD helper."""
+
+from __future__ import annotations
+
+import unittest
+
+import pandas as pd
+
+from src.make_ipd import chain_fisher
+
+
+class ChainFisherTest(unittest.TestCase):
+    """Validate the numerical behaviour of the chain Fisher helper."""
+
+    def test_normalizes_base(self) -> None:
+        """The resulting series should start at 1 regardless of raw scaling."""
+
+        data = pd.DataFrame(
+            {
+                "date": ["2025-01-01", "2025-01-01", "2025-06-01", "2025-06-01"],
+                "family": ["qa", "code", "qa", "code"],
+                "LCI": [2.0, 4.0, 1.0, 2.0],
+            }
+        )
+        result = chain_fisher(data)
+
+        self.assertEqual(list(result["date"].astype(str)), ["2025-01-01", "2025-06-01"])
+        self.assertEqual(result["IPD"].iloc[0], 1.0)
+        self.assertAlmostEqual(result["IPD"].iloc[1], 0.5)
+
+    def test_carries_forward_without_overlap(self) -> None:
+        """When no overlapping families exist, the index should stay flat."""
+
+        data = pd.DataFrame(
+            {
+                "date": ["2025-01-01", "2025-06-01"],
+                "family": ["qa", "code"],
+                "LCI": [3.0, 6.0],
+            }
+        )
+        result = chain_fisher(data)
+
+        self.assertEqual(result["IPD"].tolist(), [1.0, 1.0])
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor `src/generate_demo_results.py` into reusable helpers that backfill demo data, compute LCI aggregates, export LaTeX, and reuse the IPD chain-Fisher logic
- ensure demo rows carry both accuracy column names and create results directories before writing outputs
- refresh `docs/reproducibility.md` to document the demo fallback workflow and quickstart commands
- add unit tests that exercise the chain Fisher IPD helper for normalization and missing-overlap scenarios

## Testing
- python src/generate_demo_results.py
- python src/make_ipd.py
- python src/figures.py
- python src/lci_program.py
- python -m unittest tests.test_chain_fisher


------
https://chatgpt.com/codex/tasks/task_e_68e4690340fc83309124e4996ae5a91b