### PR TITLE
Improve diff target fallback handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 DOC=lci_paper
 BUILD=build
 PDF=$(BUILD)/$(DOC).pdf
+DIFF_TEX=$(BUILD)/$(DOC)-diff.tex
 DIFF_OUT=$(BUILD)/$(DOC)-diff.pdf
+PYTHON ?= python3
+FALLBACK ?= $(PYTHON) scripts/fallback_pdf.py
+FALLBACK_DIFF ?= $(PYTHON) scripts/fallback_latexdiff.py
 
 .PHONY: all pdf clean clobber diff lint
 
@@ -22,11 +26,23 @@ clobber:
 # usage: make diff OLD=origin/main NEW=HEAD
 diff:
 	@test -n "$(OLD)" && test -n "$(NEW)" || (echo "Usage: make diff OLD=<ref> NEW=<ref>"; exit 1)
+	@mkdir -p $(BUILD)
 	@git show $(OLD):$(DOC).tex > /tmp/old.tex
 	@git show $(NEW):$(DOC).tex > /tmp/new.tex
-	@latexdiff /tmp/old.tex /tmp/new.tex > $(BUILD)/$(DOC)-diff.tex
-	@latexmk -pdf -silent $(BUILD)/$(DOC)-diff.tex
-	@echo "Diff PDF -> $(DIFF_OUT)"
+	@RAN_REAL_DIFF=0; \
+	if command -v latexdiff >/dev/null 2>&1; then \
+		RAN_REAL_DIFF=1; \
+		latexdiff /tmp/old.tex /tmp/new.tex > $(DIFF_TEX); \
+	else \
+		echo "latexdiff unavailable; using textual fallback."; \
+		$(FALLBACK_DIFF) /tmp/old.tex /tmp/new.tex $(DIFF_TEX); \
+		$(FALLBACK) $(DIFF_TEX) $(DIFF_OUT); \
+		echo "Fallback diff PDF (textual) -> $(DIFF_OUT)"; \
+	fi; \
+	if [ $$RAN_REAL_DIFF -eq 1 ]; then \
+		latexmk -pdf -silent $(DIFF_TEX); \
+		echo "Diff PDF -> $(DIFF_OUT)"; \
+	fi
 
 lint:
 	chktex -q -n1 -n8 -n36 $(DOC).tex || true


### PR DESCRIPTION
## Summary
- add helper variables for diff artifacts and fallback helpers in the Makefile
- gate the latexdiff/latexmk branch so the textual fallback path skips TeX tools
- invoke the fallback renderer directly and print a clearer status message when used

## Testing
- make diff OLD=HEAD NEW=HEAD

------
https://chatgpt.com/codex/tasks/task_e_68e483f03dcc8330b0916902b05bfafa